### PR TITLE
Add Archon to Tools and MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@
 ### Tools and MCP servers
 
 <details>
+  <summary><strong><a href="https://github.com/coleam00/Archon">Archon</a></strong> MCP server and knowledge management platform for AI coding assistants.</summary>
+
+  <blockquote>Archon provides custom knowledge bases with web crawling, vector search, and task management capabilities, supporting multiple LLMs and offering 10 MCP tools for enhanced RAG queries and collaborative development workflows.</blockquote>
+</details>
+
+<details>
 <summary><strong><a href="https://github.com/nikvdp/cco">cco</a></strong> protective wrapper for Claude Code with zero-config sandboxed execution.</summary>
 
 <blockquote>cco provides automatic sandboxing for Claude Code using native OS tools or Docker fallback, enabling secure isolated interactions while maintaining seamless user experience and preserving project context across platforms.</blockquote>


### PR DESCRIPTION
Closes #11

### Summary
Added Archon to the Tools and MCP servers section of README.md based on repository analysis.

### Validation Checklist
- [x] Links reachable (GitHub repository accessible)
- [x] Not a duplicate (checked existing entries)
- [x] Entry formatted (details element with proper HTML)
- [x] Sorted alphabetically (positioned correctly in section)

### Category Analysis
- **Detected Category:** Tools and MCP servers
- **Reasoning:** Archon is an MCP server that provides knowledge management and task management capabilities for AI coding assistants

### Sources
- GitHub repository analysis: https://github.com/coleam00/Archon
- Issue submission data

Generated with [Claude Code](https://claude.ai/code)