### PR TITLE
Add Zed to Agents

### DIFF
--- a/data.toml
+++ b/data.toml
@@ -83,6 +83,15 @@ open_source = true
 summary = "AI coding assistant CLI for exploring, developing, and automating software workflows."
 detail = "Qwen Code is an intelligent command-line tool that helps developers understand, refactor, and generate code using advanced AI models. It provides workflow automation, code analysis, and supports multiple authentication methods across different regional providers."
 
+[[agents]]
+name = "Zed"
+website = "https://zed.dev/"
+repo = "https://github.com/zed-industries/zed"
+open_source = true
+summary = "High-performance collaborative code editor with AI-powered agentic editing capabilities."
+detail = "Zed is a next-generation code editor built in Rust that enables fluent collaboration between humans and AI. Features native AI integration for code generation and transformation with upcoming LLM support, multiplayer editing, and custom language models for edit prediction."
+category = "Open source"
+
 [[apps]]
 name = "Kiro"
 website = "https://kiro.dev/"


### PR DESCRIPTION
Closes #54

Adds Zed IDE to the Agents category based on community submission.

## Validation Checklist
- [x] Links reachable
- [x] Not a duplicate
- [x] Entry added to data.toml with proper TOML syntax
- [x] All required fields provided

## Category Selection
**Category:** Agents (auto-detected from website analysis)
**Rationale:** Zed features "agentic editing" capabilities and AI-powered code generation/transformation

## Sources
- Website analysis: https://zed.dev/
- GitHub repository: https://github.com/zed-industries/zed
- Community submission ##54

Generated with [Claude Code](https://claude.ai/code)