### PR TITLE
Add Superdesign to Tools and MCP servers

### DIFF
--- a/data.toml
+++ b/data.toml
@@ -211,7 +211,7 @@ repo = "https://github.com/superdesigndev/superdesign"
 open_source = true
 summary = "Open source AI design agent for generating UI mockups and components inside IDEs."
 detail = "Superdesign integrates directly into VS Code, Cursor, Windsurf, and Claude Code to generate UI screens, wireframes, and reusable components from natural language prompts. Enables parallel design exploration and rapid prototyping within development environments, eliminating context switching between design and coding workflows."
-category = "Other tools"
+category = "Design"
 
 [[tools]]
 name = "Task Master"
@@ -246,4 +246,4 @@ summary = "AI-powered web development platform for creating apps and websites th
 detail = "Lovable enables users to create applications and websites by chatting with AI, offering collaborative workspaces, GitHub sync, and Supabase integrations. The platform supports various project types from prototypes to production apps with deployment options and MCP server capabilities for enhanced AI development workflows."
 
 [categories]
-tools = ["Memory", "Task management", "Codebase understanding", "Security", "Other tools", "Agent feedback"]
+tools = ["Memory", "Task management", "Codebase understanding", "Security", "Other tools", "Agent feedback", "Design"]

--- a/data.toml
+++ b/data.toml
@@ -205,6 +205,15 @@ category = "Agent feedback"
 hot = true
 
 [[tools]]
+name = "Superdesign"
+website = "https://www.superdesign.dev/"
+repo = "https://github.com/superdesigndev/superdesign"
+open_source = true
+summary = "Open source AI design agent for generating UI mockups and components inside IDEs."
+detail = "Superdesign integrates directly into VS Code, Cursor, Windsurf, and Claude Code to generate UI screens, wireframes, and reusable components from natural language prompts. Enables parallel design exploration and rapid prototyping within development environments, eliminating context switching between design and coding workflows."
+category = "Other tools"
+
+[[tools]]
 name = "Task Master"
 website = "https://www.task-master.dev/"
 repo = ""


### PR DESCRIPTION
**Summary:**

Adds Superdesign, an open source AI design agent for generating UI mockups and components inside IDEs, to the Tools and MCP servers section.

**Details:**
- **Links validated:** Website and GitHub repo are accessible
- **Category:** Tools and MCP servers (IDE extension/tool)
- **No duplicates found** in existing data.toml
- **Auto-generated content** from comprehensive website analysis

**Validation Checklist:**
- [x] Links reachable
- [x] Not a duplicate
- [x] Entry added to data.toml with proper TOML syntax
- [x] All required fields provided

**Sources:** Website analysis (https://www.superdesign.dev/) + GitHub repository

Closes #62

---

Generated with [Claude Code](https://claude.ai/code)