### PR TITLE
Add VibeTunnel to Agent Interfaces

### DIFF
--- a/data.toml
+++ b/data.toml
@@ -158,6 +158,14 @@ open_source = true
 summary = "Mobile client for Claude Code with remote access and cross-device synchronization."
 detail = "Happy enables developers to control Claude Code sessions remotely via mobile and web apps, providing push notifications, instant device switching, and end-to-end encrypted code transmission across iOS, Android, and web platforms."
 
+[[interfaces]]
+name = "VibeTunnel"
+website = "https://vt.sh/"
+repo = "https://github.com/amantus-ai/vibetunnel"
+open_source = true
+summary = "Web-based terminal proxy enabling browser access to Mac terminals with remote capabilities."
+detail = "VibeTunnel turns any browser into a Mac terminal interface with zero configuration, supporting multiple terminal sessions, Git follow mode, and remote access via Tailscale or ngrok. Features AI agent monitoring and dynamic terminal titles for enhanced development workflows."
+
 [[tools]]
 name = "Archon"
 website = "https://github.com/coleam00/Archon"


### PR DESCRIPTION
Closes #65

Adds VibeTunnel, a web-based terminal proxy that enables browser access to Mac terminals with remote capabilities.

**Validation Checklist:**
- [x] Links reachable (website redirects to vibetunnel.sh)
- [x] Not a duplicate
- [x] Entry added to data.toml with proper TOML syntax
- [x] All required fields provided

**Category:** Agent Interfaces (auto-detected from website content)

**Sources:** Website analysis (vt.sh → vibetunnel.sh) + GitHub repository README

Generated with [Claude Code](https://claude.ai/code)