### PR TITLE
Add Conductor to Agent interfaces

### DIFF
--- a/data.toml
+++ b/data.toml
@@ -110,6 +110,14 @@ summary = "Desktop GUI for Claude Code with session management and custom agent 
 detail = "Claudia provides a visual command center for Claude Code featuring project browsers, session history tracking, custom AI agents with background execution, usage analytics, and process isolation for secure AI-assisted development workflows."
 
 [[interfaces]]
+name = "Conductor"
+website = "https://conductor.build/"
+repo = ""
+open_source = false
+summary = "Desktop application for parallel management and orchestration of Claude Code agents."
+detail = "Conductor enables running multiple Claude Code agents simultaneously with isolated workspaces, progress monitoring, and git worktree management. Built for developers seeking to maximize AI-assisted coding productivity through parallel agent workflows."
+
+[[interfaces]]
 name = "Agentrooms"
 website = ""
 repo = "https://github.com/baryhuang/claude-code-by-agents"


### PR DESCRIPTION
Adds Conductor desktop application to the Agent interfaces section based on issue #72 submission.

**Changes:**
- Added Conductor to `[[interfaces]]` section of data.toml
- Generated summary and detail from website analysis
- Verified no duplicates exist

**Validation checklist:**
- [x] Links reachable and analyzed
- [x] Not a duplicate
- [x] Entry added to data.toml with proper TOML syntax
- [x] All required fields provided

Closes #72

Generated with [Claude Code](https://claude.ai/code)