### PR TITLE
Add cchistory to Tools and MCP servers

### DIFF
--- a/data.toml
+++ b/data.toml
@@ -230,6 +230,16 @@ category = "Security"
 agents = ["claude-code"]
 
 [[tools]]
+name = "cchistory"
+website = ""
+repo = "https://github.com/eckardt/cchistory"
+open_source = true
+summary = "Shell history tracker for Claude Code, extracting and organizing AI-executed commands across projects."
+detail = "cchistory is a command-line tool that captures and displays shell commands executed during Claude Code conversations, allowing developers to review, search, and analyze command history across different projects. It provides a seamless way to track and learn from AI-generated shell interactions."
+category = "Other tools"
+agents = ["claude-code"]
+
+[[tools]]
 name = "Code Conductor"
 website = ""
 repo = "https://github.com/ryanmac/code-conductor"


### PR DESCRIPTION
Closes #91

Adds cchistory, a CLI tool for tracking shell command history from Claude Code sessions.

**Validation Checklist:**
- [x] Links reachable
- [x] Not a duplicate
- [x] Entry added to data.toml with proper TOML syntax
- [x] All required fields provided

**Source:** GitHub repository analysis

**Note:** README.md will be automatically updated when this PR is merged

🤖 Generated with [Claude Code](https://claude.ai/code)